### PR TITLE
Updating Ubuntu from 20.04 to 22.04 for glib libraries

### DIFF
--- a/node/bifrost-collator-mainnet.md
+++ b/node/bifrost-collator-mainnet.md
@@ -2,7 +2,7 @@
 
 ### Hareware Requirements
 
-**System: Ubuntu 20.04**
+**System: Ubuntu 22.04**
 
 * **CPU** - 4 core (3.2GHZ above)
 * **Memory** - 16GB
@@ -13,7 +13,7 @@
 
 ### Operating System
 
-`Ubuntu 20.04 LTS`
+`Ubuntu 22.04 LTS`
 
 ### Operating Procedures
 

--- a/node/bifrost-collator-obt.md
+++ b/node/bifrost-collator-obt.md
@@ -15,7 +15,7 @@
 
 ### Operating System
 
-`Ubuntu 20.04.3 LTS`
+`Ubuntu 24.04 LTS`
 
 ### Operating Procedures
 

--- a/node/bifrost-collator-obt.md
+++ b/node/bifrost-collator-obt.md
@@ -15,7 +15,7 @@
 
 ### Operating System
 
-`Ubuntu 24.04 LTS`
+`Ubuntu 22.04 LTS`
 
 ### Operating Procedures
 

--- a/node/bifrost-collator-obt.md
+++ b/node/bifrost-collator-obt.md
@@ -4,7 +4,7 @@
 
 ### Hareware Requirements
 
-**System: Ubuntu 20.04**
+**System: Ubuntu 22.04**
 
 * **CPU** - 4 core (3.2GHZ above)
 * **Memory** - 16GB


### PR DESCRIPTION
Hello,

I'm starting to do some testing for setting up a validator and ran into some missing glibc libraries on 20.04 and wanted to update the docs to 22.04. I also believe there is an open issue for this as well: https://github.com/bifrost-finance/bifrost/issues/886 

-Frazz